### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,20 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
-    "dependencyDashboard": true
+    "rangeStrategy": "bump",
+    "dependencyDashboard": true,
+    "pinDigests": true,
+    "branchPrefix": "deps/",
+    "packageRules": [
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": ["*"],
+            "groupName": "all dependencies",
+            "groupSlug": "all"
+        }
+    ]
 }


### PR DESCRIPTION
Updated renovate.json with standardised config via repoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Update renovate config

This pull request updates the `renovate.json` configuration file with standardized settings via repoRanger.

### Changes Made

**renovate.json** (+16 lines, -1 line):
- Added `rangeStrategy: "bump"` to control version range strategy
- Enabled `pinDigests: true` to pin digest versions
- Set `branchPrefix: "deps/"` for dependency update branch naming
- Introduced `packageRules` configuration with two rules:
  - Disabled major version updates for composer-managed packages
  - Grouped all dependencies under a single grouping ("all dependencies" / "all") for consolidated dependency updates

The existing `dependencyDashboard: true` configuration remains in place.

### Impact

These configuration changes standardize the renovate setup to provide:
- More consistent dependency update branch naming
- Grouped dependency updates to reduce the number of pull requests
- Prevention of major version bumps for composer packages, reducing breaking change risk
- Pinned digest versions for improved reproducibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->