### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,17 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },


### PR DESCRIPTION
Updated renovate config via 🤠 RepoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated Renovate configuration to add three new package rules that disable specific dependency updates:

- Disable updates for PHP dependencies managed by Composer
- Disable updates for Node.js and Yarn dependencies managed by npm  
- Disable major version updates for all dependencies managed by npm or Composer

These rules prevent automatic updates for the specified dependency types while maintaining the existing grouped dependency rule. The changes were generated automatically via RepoRanger.

**Files changed:** `renovate.json` (+10 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->